### PR TITLE
Update setup_your_environment.md

### DIFF
--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -48,8 +48,8 @@ Let's walk through what this application does:
 
 1. We get the first argument passed to the application, and store it in the
    `url` constant.
-2. We make a request to the url specified, await the response, and store it in the
-   `res` constant.
+2. We make a request to the url specified, await the response, and store it in
+   the `res` constant.
 3. We parse the response body as an
    [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer),
    await the response, and convert it into a

--- a/docs/getting_started/permissions.md
+++ b/docs/getting_started/permissions.md
@@ -6,9 +6,10 @@
 
 ### Permissions whitelist
 
-Deno also provides permissions whitelist.
+Deno also allows you to control the granularity of permissions with whitelists.
 
-This is an example to restrict file system access by whitelist.
+This example restricts file system access by whitelisting only the `/usr`
+directory:
 
 ```shell
 $ deno run --allow-read=/usr https://deno.land/std/examples/cat.ts /etc/passwd
@@ -18,15 +19,15 @@ error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with t
     ...
 ```
 
-You can grant read permission under `/etc` dir
+Try it out again with the correct permissions by whitelisting `/etc` instead:
 
 ```shell
 $ deno run --allow-read=/etc https://deno.land/std/examples/cat.ts /etc/passwd
 ```
 
-`--allow-write` works same as `--allow-read`.
+`--allow-write` works the same as `--allow-read`.
 
-This is an example to restrict host.
+This example restricts network access by whitelisting the allowed hosts:
 
 ```ts
 const result = await fetch("https://deno.land/");

--- a/docs/getting_started/setup_your_environment.md
+++ b/docs/getting_started/setup_your_environment.md
@@ -6,7 +6,7 @@ IDE of choice.
 
 ### Environmental variables
 
-There are several env vars that control how Deno behaves:
+There are several environment variables that control how Deno behaves:
 
 `DENO_DIR` defaults to `$HOME/.deno` but can be set to any path to control where
 generated and cached source code is written and read to.
@@ -18,7 +18,7 @@ boolean constant `Deno.noColor`.
 ### Shell autocomplete
 
 You can generate completion script for your shell using the
-`deno completions <shell>` command. The command outputs to stdout so you should
+`deno completions <shell>` command. The command outputs to stdout, so you should
 redirect it to an appropriate file.
 
 The supported shells are:


### PR DESCRIPTION
Changed the shorthand form 'env vars' to align with previous uses of the term, and added a comma between "The command outputs to stdout" and "so you should redirect it to an appropriate file".

<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->
